### PR TITLE
Parameterize release version for OWASP scans

### DIFF
--- a/owasp/netcdf-java/release
+++ b/owasp/netcdf-java/release
@@ -11,7 +11,7 @@ pipeline {
             steps {
                 checkout([
                     $class                           : 'GitSCM',
-                    branches                         : [[name: "refs/tags/v5.9.1"]],
+                    branches                         : [[name: "refs/tags/${env.NCJ_RELEASE_TAG}"]],
                     userRemoteConfigs                : [[url: 'https://github.com/Unidata/netcdf-java']],
                     extensions                       : [cloneOption(depth: 1, reference: '', shallow: true)],
                     doGenerateSubmoduleConfigurations: false

--- a/owasp/tds/main
+++ b/owasp/tds/main
@@ -23,7 +23,7 @@ pipeline {
                 sh '''#!/bin/bash -l
                    select-java temurin 17
                    chmod u+x gradlew
-                   ./gradlew clean assemble
+                   ./gradlew clean :tdm:assemble :tds:assemble
                 '''
             }
         }

--- a/owasp/tds/release
+++ b/owasp/tds/release
@@ -11,7 +11,7 @@ pipeline {
             steps {
                 checkout([
                     $class                           : 'GitSCM',
-                    branches                         : [[name: "refs/tags/v5.7"]],
+                    branches                         : [[name: "refs/tags/${env.TDS_RELEASE_TAG}"]],
                     userRemoteConfigs                : [[url: 'https://github.com/Unidata/tds']],
                     extensions                       : [cloneOption(depth: 1, reference: '', shallow: true)],
                     doGenerateSubmoduleConfigurations: false
@@ -23,7 +23,7 @@ pipeline {
                 sh '''#!/bin/bash -l
                    select-java temurin 17
                    chmod u+x gradlew
-                   ./gradlew clean assemble
+                   ./gradlew clean :tdm:assemble :tds:assemble
                 '''
             }
         }


### PR DESCRIPTION
When running the OWASP scan jobs for release versions of netCDF-Java and TDS, use a jenkins-defined environment variable for setting the branch. This means we can update the release branch from within Jenkins and not need to update the pipeline for every release. Also, only build the tdm and tds artifacts when scanning the TDS project.